### PR TITLE
fix(ci): deploy-monitoring 에 .env 로드 추가

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -99,6 +99,12 @@ jobs:
             set -euxo pipefail
             cd /home/ubuntu/desktop/deploy
 
+            # .env 로드 — docker-stack.monitoring.yml 의 ${GRAFANA_ADMIN_USER}, ${GRAFANA_ADMIN_PASSWORD} 치환용
+            # (set -a: 이후 source 한 변수를 자동 export 해서 docker stack deploy 가 읽을 수 있게 함)
+            set -a
+            source /home/ubuntu/desktop/deploy/sys/config/env/.env
+            set +a
+
             echo "=== [prod 1/5] Files check ==="
             ls -la infra/prometheus/prometheus.yml
             ls -la infra/grafana/provisioning/datasources/datasources.yml


### PR DESCRIPTION
docker-stack.monitoring.yml 의 ${GRAFANA_ADMIN_USER}/${GRAFANA_ADMIN_PASSWORD} 치환이 stack deploy 시점 shell env 기준인데 워크플로우가 .env 를 source 하지 않아 빈 문자열로 치환 → Grafana 가 기본 admin/admin 으로 기동.

set -a + source .env + set +a 로 Grafana env 주입 정상화.

주의: 현재 이미 기동된 Grafana 는 grafana-data 볼륨에 비번 저장된 상태라 재배포해도 자동 변경 안 됨. admin/admin 로그인 후 UI 에서 비번 변경 필요.