### PR TITLE
fix(monitor): node_exporter hostname 템플릿 + Prometheus 단순화

### DIFF
--- a/infra/docker-stack.monitoring.shared.yml
+++ b/infra/docker-stack.monitoring.shared.yml
@@ -11,10 +11,21 @@ version: '3.9'
 services:
   node_exporter:
     image: prom/node-exporter:v1.8.2
+    # Swarm 템플릿으로 컨테이너 hostname 을 노드 hostname(fs-01/02/03)으로 설정.
+    # → node_uname_info 메트릭의 nodename label 이 실제 노드명으로 기록되어
+    #    Grafana Dashboard 1860 의 Nodename 드롭다운이 정상 채워짐.
+    hostname: '{{.Node.Hostname}}'
+    # 호스트의 /proc, /sys, / 를 별도 bind → 컨테이너 파일시스템이 아닌
+    # 호스트 메트릭을 수집 (node_exporter 공식 권장 배포 구성).
     command:
-      - '--path.rootfs=/host'
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--path.rootfs=/rootfs'
+      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
     volumes:
-      - '/:/host:ro,rslave'
+      - '/proc:/host/proc:ro'
+      - '/sys:/host/sys:ro'
+      - '/:/rootfs:ro'
     networks:
       - sys_default
     deploy:

--- a/infra/docker-stack.monitoring.yml
+++ b/infra/docker-stack.monitoring.yml
@@ -23,9 +23,6 @@ services:
         target: /etc/prometheus/prometheus.yml
     volumes:
       - prometheus-data:/prometheus
-      # Swarm API 조회용 (노드 hostname 을 instance label 로 주입 — prometheus.yml 참조)
-      # manager 노드 필수 → placement constraint(prod_monitor_metrics=1) 및 fs-02 manager 구성으로 충족
-      - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - sys_default
     deploy:

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -24,26 +24,14 @@ scrape_configs:
         type: A
         port: 3500
 
-  # node_exporter — Swarm 노드별 hostname을 instance label 로 주입.
-  # dockerswarm_sd_configs + relabel 로 노드 메타 획득 (IP 대신 fs-01/02/03).
-  # 조건: Prometheus 컨테이너가 manager 노드에 있고 /var/run/docker.sock 마운트 필요.
+  # node_exporter — shared 스택 global 배포, 모든 노드 1개씩.
+  # 노드 hostname 은 node_exporter 컨테이너의 hostname: '{{.Node.Hostname}}' 템플릿으로
+  # node_uname_info{nodename=...} 에 주입됨 → Grafana 대시보드에서 fs-01/02/03 표시.
   - job_name: 'node_exporter'
-    dockerswarm_sd_configs:
-      - host: unix:///var/run/docker.sock
-        role: nodes
-    relabel_configs:
-      # scrape 주소를 노드 IP:9100 으로 (role:nodes는 포트 제공 X → 수동 지정)
-      - source_labels: [__meta_dockerswarm_node_address]
-        target_label: __address__
-        replacement: ${1}:9100
-      # instance label = 노드 hostname (fs-01/fs-02/fs-03)
-      - source_labels: [__meta_dockerswarm_node_hostname]
-        target_label: instance
-      # (선택) 노드 역할/가용성도 label 로 보존
-      - source_labels: [__meta_dockerswarm_node_availability]
-        target_label: node_availability
-      - source_labels: [__meta_dockerswarm_node_role]
-        target_label: node_role
+    dns_sd_configs:
+      - names: ['tasks.monitor_shared_node_exporter']
+        type: A
+        port: 9100
 
   # Prometheus self-monitoring
   - job_name: 'prometheus_self'


### PR DESCRIPTION
dockerswarm_sd + Docker socket 조합은 현재 규모에 과잉 설계.
더 단순한 Swarm hostname 템플릿 방식으로 roll-back.

docker-stack.monitoring.shared.yml (node_exporter)
- hostname: '{{.Node.Hostname}}' 추가 → Swarm 런타임이 각 노드 hostname(fs-01/02/03)으로 치환 → node_uname_info{nodename=...} 메트릭에 실제 노드명 기록 → Grafana Dashboard 1860 의 Nodename 드롭다운 자동 채움
- 마운트 공식 권장 구성: /proc, /sys, /:/rootfs + --path.rootfs=/rootfs

docker-stack.monitoring.yml (prometheus)
- user: "root" 제거 → 기본 nobody 유저로 복귀 (보안 강화)
- /var/run/docker.sock 마운트 제거 → Docker API 접근 불필요

prometheus.yml (node_exporter scrape)
- dockerswarm_sd_configs + relabel_configs 제거
- 단순 dns_sd_configs (tasks.monitor_shared_node_exporter:9100) 로 원복

참고: Prometheus /targets 의 instance label 은 여전히 IP:port 지만 Grafana 대시보드 모든 패널은 node_uname_info.nodename 기반이라
fs-01/02/03 로 정상 표시.