### PR TITLE
feat(monitor): Loki + Promtail 로그 중앙 수집 + Prometheus replica 라벨

### DIFF
--- a/.github/workflows/deploy-monitoring.yml
+++ b/.github/workflows/deploy-monitoring.yml
@@ -40,11 +40,12 @@ jobs:
           chmod 600 /tmp/ssh_key
           rsync -avz --relative \
             -e "ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no" \
+            infra/promtail \
             infra/docker-stack.monitoring.shared.yml \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_SERVER }}:/home/ubuntu/desktop/deploy/
           rm /tmp/ssh_key
 
-      - name: Deploy shared stack via SSH (converge 동기 대기)
+      - name: Deploy shared stack via SSH (sha256 config + converge 동기 대기)
         uses: appleboy/ssh-action@v1.0.0
         with:
           host: ${{ secrets.DEPLOY_SERVER }}
@@ -55,13 +56,27 @@ jobs:
             set -euxo pipefail
             cd /home/ubuntu/desktop/deploy
 
-            echo "=== [shared 1/2] Stack deploy ==="
+            echo "=== [shared 1/4] Hash calc ==="
+            PROMTAIL_CFG_HASH=$(sha256sum infra/promtail/promtail-config.yml | awk '{print $1}' | cut -c1-12)
+            export PROMTAIL_CFG_HASH
+            echo "PROMTAIL_CFG_HASH=$PROMTAIL_CFG_HASH"
+            test -n "$PROMTAIL_CFG_HASH"
+
+            echo "=== [shared 2/4] Stack deploy ==="
             docker stack deploy --detach=false \
               -c infra/docker-stack.monitoring.shared.yml \
               monitor_shared
 
-            echo "=== [shared 2/2] Services status ==="
+            echo "=== [shared 3/4] Services status ==="
             docker stack services monitor_shared
+
+            echo "=== [shared 4/4] Cleanup orphaned promtail configs ==="
+            for cfg in $(docker config ls --filter "name=prod_monitor_promtail_" --format "{{.Name}}"); do
+              if docker config rm "$cfg" 2>/dev/null; then
+                echo "removed orphan: $cfg"
+              fi
+            done
+            echo "cleanup done"
 
   # ============================================
   # 2단계: prod 스택 (Prometheus — Grafana/Alertmanager/Loki는 Step 3/6에서 추가)
@@ -84,6 +99,7 @@ jobs:
             -e "ssh -i /tmp/ssh_key -o StrictHostKeyChecking=no" \
             infra/prometheus \
             infra/grafana \
+            infra/loki \
             infra/docker-stack.monitoring.yml \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_SERVER }}:/home/ubuntu/desktop/deploy/
           rm /tmp/ssh_key
@@ -109,17 +125,20 @@ jobs:
             ls -la infra/prometheus/prometheus.yml
             ls -la infra/grafana/provisioning/datasources/datasources.yml
             ls -la infra/grafana/provisioning/dashboards/dashboards.yml
+            ls -la infra/loki/loki-config.yml
             ls -la infra/docker-stack.monitoring.yml
 
             echo "=== [prod 2/5] Hash calc ==="
             PROM_CFG_HASH=$(sha256sum infra/prometheus/prometheus.yml | awk '{print $1}' | cut -c1-12)
             GRAFANA_DS_CFG_HASH=$(sha256sum infra/grafana/provisioning/datasources/datasources.yml | awk '{print $1}' | cut -c1-12)
             GRAFANA_DASH_CFG_HASH=$(sha256sum infra/grafana/provisioning/dashboards/dashboards.yml | awk '{print $1}' | cut -c1-12)
-            export PROM_CFG_HASH GRAFANA_DS_CFG_HASH GRAFANA_DASH_CFG_HASH
+            LOKI_CFG_HASH=$(sha256sum infra/loki/loki-config.yml | awk '{print $1}' | cut -c1-12)
+            export PROM_CFG_HASH GRAFANA_DS_CFG_HASH GRAFANA_DASH_CFG_HASH LOKI_CFG_HASH
             echo "PROM_CFG_HASH=$PROM_CFG_HASH"
             echo "GRAFANA_DS_CFG_HASH=$GRAFANA_DS_CFG_HASH"
             echo "GRAFANA_DASH_CFG_HASH=$GRAFANA_DASH_CFG_HASH"
-            test -n "$PROM_CFG_HASH" && test -n "$GRAFANA_DS_CFG_HASH" && test -n "$GRAFANA_DASH_CFG_HASH"
+            echo "LOKI_CFG_HASH=$LOKI_CFG_HASH"
+            test -n "$PROM_CFG_HASH" && test -n "$GRAFANA_DS_CFG_HASH" && test -n "$GRAFANA_DASH_CFG_HASH" && test -n "$LOKI_CFG_HASH"
 
             echo "=== [prod 3/5] Stack deploy ==="
             docker stack deploy --detach=false \

--- a/docs/tasks-logging.md
+++ b/docs/tasks-logging.md
@@ -71,10 +71,10 @@
 
 ## 📦 패키지 및 도구
 
-| 도구 | 버전 (추천) | 역할 |
+| 도구 | 버전 | 역할 |
 |------|-----------|------|
-| Loki | `grafana/loki:3.1.0` | 로그 저장·쿼리 서버 |
-| Promtail | `grafana/promtail:3.1.0` | 로그 수집 에이전트 (docker discovery) |
+| Loki | `grafana/loki:3.4.2` | 로그 저장·쿼리 서버 (mobisell prod 검증 버전) |
+| Promtail | `grafana/promtail:3.4.2` | 로그 수집 에이전트 (docker discovery) |
 
 **앱 레벨 추가 설치 없음** — Pino 이미 도입되어 stdout JSON 출력 중.
 
@@ -173,29 +173,28 @@ scrape_configs:
       # 필요 시 아래 pipeline_stages.structured_metadata에서 보존 (인덱스 영향 없음)
 
     pipeline_stages:
-      # Pino JSON 파싱 (실패 시 해당 stage만 스킵, 로그는 정상 raw line으로 수집됨)
+      # Pino JSON 파싱 — non-JSON 로그(Redis, Caddy 등)는 json stage 가 실패해도
+      # drop 되지 않고 raw line 그대로 수집됨 (Promtail 기본 동작)
       - json:
           expressions:
             level: level
             time: time
             msg: msg
 
-      # level만 저카디널리티 레이블로 승격 (info/warn/error/debug — 4개)
+      # level 만 저카디널리티 레이블로 승격 (info/warn/error/debug — 4개)
       - labels:
           level:
 
-      # 타임스탬프 교정 (Pino는 ms epoch)
+      # 타임스탬프 교정 — bun 의 logger.module.ts 는 pino.stdTimeFunctions.isoTime 사용.
+      # 출력 형식: "time":"2024-01-01T00:00:00.000Z" (RFC 3339)
+      # Go 의 RFC3339Nano 포맷은 ms/ns precision 모두 허용하므로 단일 format 으로 OK.
+      # ⚠️ Pino 기본값(epochTime, ms number) 사용 시에는 format: UnixMs 로 전환 필요.
       - timestamp:
           source: time
-          format: UnixMs
-
-      # container_name은 structured_metadata로 저장 — 인덱스 미영향, LogQL에서 필터 가능
-      # Loki 3.0+ + limits_config.allow_structured_metadata: true 필요 (loki-config.yml에 활성화됨)
-      - structured_metadata:
-          container_name: container_name
-
-      # non-JSON 로그(Redis, Caddy 등)는 json stage가 실패해도 raw line으로 정상 수집
+          format: RFC3339Nano
 ```
+
+> **container_name 제외 결정**: 설계 초안은 container_name 을 structured_metadata 로 저장하려 했으나, Promtail 은 docker_sd 의 `__meta_docker_container_name` 을 pipeline extracted map 에 직접 주입하는 표준 수단이 없음 (structured_metadata stage 는 extracted map 값만 받음). index label 로 승격하면 Swarm 재시작마다 container_id 가 바뀌어 고카디널리티 유발. 따라서 **저장하지 않고 필요 시 LogQL line 필터** (`|= "container_id"`) 로 검색.
 
 ### Step 2 — Loki 설정 파일
 
@@ -248,7 +247,7 @@ Loki는 `docker-stack.monitoring.yml` (prod 스택)에, Promtail은 `docker-stac
 ```yaml
 services:
   loki:
-    image: grafana/loki:3.1.0
+    image: grafana/loki:3.4.2
     user: "10001:10001"   # Loki 기본 uid/gid — 볼륨 권한 일관성
     command: -config.file=/etc/loki/config.yml
     volumes:
@@ -268,7 +267,7 @@ services:
         condition: on-failure
 
   promtail:
-    image: grafana/promtail:3.1.0
+    image: grafana/promtail:3.4.2
     # Promtail은 docker.sock 접근이 필요하므로 기본 root 유지 (user 지시어 명시 안 함)
     command: -config.file=/etc/promtail/config.yml
     volumes:
@@ -478,7 +477,7 @@ Step 1 — Promtail 설정:
   [ ] infra/promtail/promtail-config.yml 작성
   [ ] docker_sd_configs + relabel_configs (저카디널리티 레이블만: service, env, cluster)
   [ ] pipeline_stages: Pino JSON 파싱 (level, time, msg) → level 레이블 승격
-  [ ] structured_metadata stage로 container_name 보존 (인덱스 미영향)
+  [ ] timestamp stage: format RFC3339Nano (Pino isoTime 출력 매칭)
 
 Step 2 — Loki 설정:
   [ ] infra/loki/loki-config.yml 작성
@@ -501,9 +500,10 @@ Step 4 — Grafana 데이터소스 (Provisioning):
   [ ] Explore 탭에서 {service="prod_nest_app"} 쿼리 → 로그 출력 확인
 
 Step 5 — Pino 포맷 + 보안:
-  [ ] PROD stdout JSON 형식 재확인 (level, time, msg)
-  [ ] Pino redact 설정 (password, token, cookie, authorization)
-  [ ] Pino serializers 설정 (req, res, err 구조 통일)
+  [x] PROD stdout JSON 형식 (level, time, msg) — logger.module.ts 기구현
+  [x] Pino redact (password, token, cookie, authorization 등 재귀) — 기구현
+  [x] Pino serializers (req, res, err 구조 통일) — 기구현
+  [x] autoLogging.ignore: /api/v1/health-check, /api/v1/metrics 제외 (PROD 한정, Loki 저장량 절감)
   [ ] 프로덕션 로그 레벨 확인 (info 기본, DEBUG 제외)
   [ ] LogQL로 파싱 확인: `{service="prod_nest_app"} | json | level="error"`
 

--- a/docs/tasks-monitoring.md
+++ b/docs/tasks-monitoring.md
@@ -33,6 +33,7 @@
 | 배치 (선택 A) | 기존 앱 노드에 공존 (4 OCPU / 24GB, 여유 충분) | 운영 단순성 |
 | 배치 (선택 B) | **OCI Always Free 1GB × 2 분리 배치** (fs-02, fs-03 / 스왑 2GB 적용 완료) | 앱 리소스 격리 (후술) |
 | Prometheus retention | **7일 (QA·PROD 동일)** (`--storage.tsdb.retention.time=7d`) | 디스크 ~200MB/월. QA 도입 시에도 동일 유지 (단순성 + 디스크 예산 고정) |
+| Redis 서버 메트릭 | **`oliver006/redis_exporter` 별도 컨테이너** (prod_monitor 스택, fs-02 배치) | 앱의 `redis_connection_status`(앱 관점)와 별개로 Redis 서버 상태(메모리·명령·keyspace) 수집. overlay DNS 로 fs-01 의 Redis 접근 |
 | scrape 간격 | `scrape_interval: 15s`, `scrape_timeout: 10s` | 표준값, 오버헤드 최소 |
 | external_labels | `env=prod`, `cluster=oci-swarm` | Grafana 환경 필터링 + 멀티 환경 확장 대비 |
 | Grafana Provisioning | **IaC** (`datasources.yml` + `dashboards.yml` + JSON 커밋) | 수동 설정 탈피, 서버 재배포 시 자동 재현 |
@@ -822,8 +823,70 @@ providers:
 - `ws_connections_active` (TeamGateway 연결/해제 시 증감)
 - `ws_team_online_users{team_id}` (OnlineUserService 주기 갱신 30s~1m)
 - `ws_events_total{event}` / `ws_event_duration_seconds{event}` (gateway handlers)
-- `redis_connection_status` (RedisIoAdapter)
+- `redis_connection_status` (RedisIoAdapter — 앱 관점 "연결되어 있나")
 - (선택) 비즈니스 메트릭: 팀 생성 수, 태스크 완료율
+
+### Step 4.1 — Redis 서버 메트릭 (redis_exporter)
+
+Step 4 의 `redis_connection_status` 는 **앱 관점**(0/1)이고, Redis **서버 자체**의 상태
+(메모리, 연결 수, 명령 처리량, keyspace 히트율 등)는 별도 exporter 필요.
+
+**배치**: `prod_monitor` 스택, fs-02 (`prod_monitor_metrics=1` 라벨). Redis 는 fs-01
+고정이지만 exporter 는 overlay DNS 로 `tasks.infra_redis:6379` 접근 — 노드 위치 무관.
+
+**4.1-1. `docker-stack.monitoring.yml` 에 서비스 추가** (→ 최종 합본은 문서 말미):
+
+```yaml
+redis-exporter:
+  image: oliver006/redis_exporter:v1.62.0
+  command:
+    - '--redis.addr=redis://tasks.infra_redis:6379'
+    # Redis AUTH 사용 시: --redis.password-file=/run/secrets/redis_password
+  networks:
+    - sys_default
+  deploy:
+    replicas: 1
+    placement:
+      constraints:
+        - node.labels.prod_monitor_metrics == 1
+    resources:
+      limits:
+        memory: 50M
+    restart_policy:
+      condition: on-failure
+  # ports 없음 → overlay 내부만 (Prometheus 가 redis-exporter:9121 scrape)
+```
+
+**4.1-2. `prometheus.yml` 에 scrape 추가**:
+
+```yaml
+scrape_configs:
+  # ... 기존 job 들 ...
+
+  # Redis 서버 메트릭 (oliver006/redis_exporter)
+  - job_name: 'redis'
+    static_configs:
+      - targets: ['tasks.prod_monitor_redis-exporter:9121']
+        labels:
+          redis_instance: 'infra_redis'    # Redis 인스턴스 식별 (멀티 Redis 대비)
+```
+
+**4.1-3. Grafana Dashboard Import**:
+- ID `763` (Redis Dashboard for Prometheus Redis Exporter 1.x) — 공식·가장 널리 쓰이는 대시보드
+- 대체: ID `11692` (Redis Dashboard for Prometheus Redis Exporter helm stable/redis-ha)
+
+**4.1-4. 수집되는 주요 메트릭**:
+- `redis_up` (0/1) — Redis 서버 응답 가능 여부. **알림 소스 (Step 6)**
+- `redis_memory_used_bytes` / `redis_memory_max_bytes` — 128MB maxmemory 대비 사용률
+- `redis_connected_clients` — 현재 연결된 클라이언트 수
+- `redis_commands_processed_total` — 명령 처리량 rate
+- `redis_keyspace_hits_total` / `redis_keyspace_misses_total` — 캐시 히트율
+- `redis_evicted_keys_total` — allkeys-lru 정책에 의한 eviction 수 (128MB 포화 감지)
+
+**4.1-5. fs-01 단일 노드 고려사항**:
+- Redis 는 fs-01 manager 에서만 (`docker-stack.yml` 의 `node.role == manager` + 실제 fs-01 배치).
+- fs-01 장애 시 → Redis 다운 → exporter scrape 실패 → `redis_up == 0` → Step 6 알림 즉시 발동.
+- 앱(NestJS)은 Redis 실패해도 HTTP 정상 (WS 프레즌스만 중단) — 이미 Step 2 Redis Pub/Sub 설계에 반영.
 
 ### Step 4.5 — Recording Rules + Loki Drill-down 준비 ⭐
 
@@ -1212,41 +1275,67 @@ Step 2 — Caddy 차단 + Prometheus + node_exporter:
   [ ] NestJS 레플리카 개별 scrape 확인 (tasks.prod_nest_app DNS) — Step 1 배포 선행 필요
   [ ] node_exporter 각 노드 확인 (tasks.monitor_shared_node_exporter DNS)
 
-Step 3 — Grafana (subpath /grafana/ + Provisioning + Caddy 노출):
+Step 3 — Grafana (subpath /grafana/ + Provisioning + Caddy 노출): ✅ 완료 (2026-04-22)
 
-  [A] Grafana 컨테이너가 읽는 env (docker-stack.monitoring.yml 의 grafana 서비스 environment):
-    [x] 서버 .env에 GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD 추가 — 완료
-        ※ GRAFANA_HOSTNAME / GRAFANA_ALLOWED_IPS 는 추가 안 함 (각각 subpath 방식 · Caddyfile 직접 작성 방식이라 불필요).
+  [A] Grafana 컨테이너 env:
+    [x] 서버 .env에 GRAFANA_ADMIN_USER / GRAFANA_ADMIN_PASSWORD 추가
+    [x] deploy-monitoring.yml 에 `set -a; source .env; set +a` 로드 (치환 실패 방지)
 
-  [B] Caddyfile 수정 (서버 /home/ubuntu/desktop/deploy/infra/caddy/config/Caddyfile):
-    [ ] @grafana_path (path matcher) + @grafana_allowed (remote_ip matcher — IP 직접 작성) + handle /grafana/* 블록 추가
-        (IP 화이트리스트 통과 시만 reverse_proxy tasks.prod_monitor_grafana:3000, 아니면 404)
-    [ ] caddy reload 실행: for cid in $(docker ps -q -f name=infra_caddy); do docker exec $cid caddy reload --config /config/Caddyfile --adapter caddyfile; done
-        (Caddy env 주입이 필요 없으므로 infra_caddy 서비스 재배포는 불필요)
+  [B] Caddyfile (서버 직접 편집):
+    [x] @grafana_path matcher + handle /grafana/* 블록 추가 (IP 화이트리스트 통과 시만 proxy)
+    [x] (allowed_ips) snippet 에 운영자 IP 직접 작성 (/32 CIDR 명시)
+    [x] caddy reload 반영 확인
 
-  [C] docker-stack.monitoring.yml 의 grafana 서비스 정의:
-    [ ] grafana 서비스 추가 (fs-03 배치, memory 350M, user 472:472)
-        - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
-        - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
-        - GF_SERVER_ROOT_URL=https://fivesouth.duckdns.org/grafana/
-        - GF_SERVER_SERVE_FROM_SUB_PATH=true
-        - GF_SERVER_DOMAIN=fivesouth.duckdns.org
-        - GF_USERS_ALLOW_SIGN_UP=false, GF_AUTH_ANONYMOUS_ENABLED=false
-        - ports 섹션 없음 (overlay 노출만)
-  [ ] infra/grafana/provisioning/datasources/datasources.yml 작성 (Prometheus uid: prometheus 고정)
-  [ ] infra/grafana/provisioning/dashboards/dashboards.yml 작성 (discovery 설정)
-  [ ] datasources.yml/dashboards.yml → Swarm configs 주입 (sha256 해시 name)
-  [ ] 대시보드 JSON 커밋: nodejs.json (11159), node-exporter.json (1860), fivesouth-custom.json
-  [ ] dashboards/json/ 디렉터리 → bind mount (read-only) 설정 확인
-  [ ] Grafana 재배포 후 https://fivesouth.duckdns.org/grafana/ 접근 확인 (허용 IP만)
-  [ ] 화이트리스트 미포함 IP에서 404 반환 확인 (보안 검증)
+  [C] Caddy host 모드 전환 (Swarm ingress IPVS SNAT 회피 — 클라이언트 IP 보존):
+    [x] infra/docker-stack.yml: ports 를 mode: host 로 전환 (80/tcp, 443/tcp, 443/udp HTTP/3)
+    [x] replicas: 2 → 1, update_config.order: stop-first
+    [x] infra 스택 재배포 완료
+
+  [D] docker-stack.monitoring.yml grafana 서비스:
+    [x] grafana 서비스 추가 (fs-03, memory 350M, user 472:472, subpath env)
+    [x] provisioning configs 2개 (datasources, dashboards) sha256 해시 naming
+
+  [E] Grafana provisioning 파일:
+    [x] infra/grafana/provisioning/datasources/datasources.yml (Prometheus uid: prometheus 고정)
+    [x] infra/grafana/provisioning/dashboards/dashboards.yml (discovery 설정)
+    [x] infra/grafana/provisioning/dashboards/json/fivesouth-custom.json (골격)
+    [x] dashboards/json/ 디렉터리 bind mount (서버 fs-03 에서 mkdir 완료)
+
+  [F] node_exporter hostname 주입 (Grafana Dashboard 1860 의 nodename 드롭다운 채움):
+    [x] docker-stack.monitoring.shared.yml: hostname: '{{.Node.Hostname}}' 추가
+    [x] /proc, /sys, /:/rootfs 호스트 별도 bind + --path.rootfs=/rootfs (공식 권장)
+    [x] prometheus.yml: dns_sd_configs 로 원복 (dockerswarm_sd + relabel 과잉 설계 제거)
+    [x] Prometheus user:root + /var/run/docker.sock 마운트 제거 (보안 복귀)
+
+  [G] 검증:
+    [x] https://fivesouth.duckdns.org/grafana/ 접속 — Grafana 로그인 페이지 노출
+    [x] 허용 IP 외에서는 404 반환 (Caddy @admin_ips 차단)
+    [x] Dashboard 1860 Import → Nodename 드롭다운에 fs-01/02/03 자동 채움
+    [x] 각 노드별 CPU/RAM/Disk/Network 실측치 표시 (RAM 957 MiB, Uptime 40.8 weeks 등)
+    [ ] Dashboard 11159 (NodeJS Application Dashboard) import — 선택
+    [ ] UI 편집 후 export → json 디렉터리 커밋 (영속화) — 선택
 
 Step 4 — 커스텀 메트릭:
   [ ] ws_connections_active (TeamGateway 연결/해제 시 증감)
   [ ] ws_team_online_users (OnlineUserService 주기 갱신 30s~1m, 팀별 labels)
+      ※ 팀 삭제 시 stale label 제거 (ws_team_online_users.remove({ team_id })) 필요
   [ ] ws_events_total / ws_event_duration_seconds (gateway handlers)
-  [ ] redis_connection_status (RedisIoAdapter)
-  [ ] (선택) 비즈니스 메트릭
+      ※ Histogram bucket 기본값 유지 (prom-client default, 10개). 커스텀 bucket 시 메모리 증가 주의
+  [ ] redis_connection_status (RedisIoAdapter on('ready'/'end'/'error'))
+  [ ] MetricsModule 분리 + makeCounterProvider/makeGaugeProvider/makeHistogramProvider 로 DI
+  [ ] OnModuleDestroy 에서 setInterval clearInterval (주기 갱신 사용 시 메모리 leak 방지)
+  [ ] (선택) 비즈니스 메트릭 (팀 생성 수, 태스크 완료율 등)
+
+Step 4.1 — Redis 서버 메트릭 (redis_exporter):
+  [ ] docker-stack.monitoring.yml 에 redis-exporter 서비스 추가
+      - 이미지 oliver006/redis_exporter:v1.62.0
+      - command: --redis.addr=redis://tasks.infra_redis:6379
+      - placement: prod_monitor_metrics=1 (fs-02)
+      - memory 50M
+  [ ] prometheus.yml 에 'redis' job 추가 (tasks.prod_monitor_redis-exporter:9121)
+  [ ] Grafana Dashboard 763 (Redis Dashboard for Prometheus Redis Exporter 1.x) Import
+  [ ] 핵심 메트릭 확인: redis_up=1, redis_memory_used_bytes, redis_commands_processed_total
+  [ ] (Step 6 연계) alerts.yml 에 RedisDown (redis_up == 0 for 1m) + RedisMemoryHigh (> 90%) 룰 추가 예약
 
 Step 4.5 — Recording Rules + Drill-down 준비:
   [ ] infra/prometheus/rules/recording.yml 작성 (p95, error_rate, active_teams 등)
@@ -1364,7 +1453,7 @@ services:
     # ports 없음 → overlay 내부에서만 노출 (Prometheus tasks.monitor_shared_node_exporter:9100)
 
   promtail-prod:
-    image: grafana/promtail:3.1.0
+    image: grafana/promtail:3.4.2
     command: -config.file=/etc/promtail/config.yml
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -1499,7 +1588,7 @@ services:
         mode: host   # SSH 터널만 접근
 
   loki:
-    image: grafana/loki:3.1.0
+    image: grafana/loki:3.4.2
     user: "10001:10001"
     command: -config.file=/etc/loki/config.yml
     configs:
@@ -1577,9 +1666,10 @@ networks:
 - `src/app.module.ts` (PrometheusModule import + MiddlewareConsumer 등록)
 - `src/common/middleware/metrics-access.middleware.ts` (신규 — XFF 1차 + IP 2차 검증)
 - `src/common/middleware/metrics-access.middleware.spec.ts` (신규 — 20+ 케이스)
+- `src/common/metrics/metrics.module.ts` (신규 — Step 4: Counter/Gauge/Histogram provider 선언, DI export)
 - `src/modules/team/team.gateway.ts` (ws_connections_active, ws_events_total, ws_event_duration_seconds)
-- `src/modules/team/online-user.service.ts` (ws_team_online_users 주기 갱신)
-- `src/common/adapters/redis-io.adapter.ts` (redis_connection_status)
+- `src/modules/team/online-user.service.ts` (ws_team_online_users 주기 갱신 + OnModuleDestroy clearInterval)
+- `src/common/adapters/redis-io.adapter.ts` (redis_connection_status — 앱 관점. Redis 서버 메트릭은 Step 4.1 redis_exporter)
 
 **인프라 설정 (신규)**:
 - `infra/docker-stack.monitoring.shared.yml` (**shared 스택** — node_exporter + promtail-prod)

--- a/infra/docker-stack.monitoring.shared.yml
+++ b/infra/docker-stack.monitoring.shared.yml
@@ -1,9 +1,11 @@
 version: '3.9'
 
 # shared 스택 — 모든 노드에서 global 실행되는 모니터링 에이전트.
-# node_exporter: OS/HW 메트릭 수집. Promtail은 tasks-logging.md 단계에서 추가.
+# - node_exporter: OS/HW 메트릭 수집
+# - promtail-prod: 컨테이너 stdout 로그 수집 → Loki push
 #
 # 배포:
+#   export PROMTAIL_CFG_HASH=$(sha256sum infra/promtail/promtail-config.yml | head -c 12)
 #   docker stack deploy --detach=false -c infra/docker-stack.monitoring.shared.yml monitor_shared
 #
 # 스택명이 monitor_shared이므로 overlay DNS는 tasks.monitor_shared_node_exporter:9100
@@ -36,6 +38,36 @@ services:
       restart_policy:
         condition: on-failure
     # ports 없음 → overlay 내부에서만 접근 (Prometheus가 DNS로 scrape)
+
+  # Promtail — 각 노드 docker.sock 을 읽어 컨테이너 stdout 을 Loki 로 push.
+  # docker.sock 은 read-only 마운트 (쓰기 불필요).
+  # 앱 코드 변경 0 (docker logging driver 그대로 json-file/journald 유지, Promtail 이 docker API 로 읽음).
+  promtail-prod:
+    image: grafana/promtail:3.4.2
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail-prod-positions:/tmp
+    configs:
+      - source: prod_monitor_promtail_yml
+        target: /etc/promtail/config.yml
+    networks:
+      - sys_default
+    deploy:
+      mode: global
+      resources:
+        limits:
+          memory: 100M
+      restart_policy:
+        condition: on-failure
+
+configs:
+  prod_monitor_promtail_yml:
+    name: prod_monitor_promtail_yml_${PROMTAIL_CFG_HASH:-latest}
+    file: ./promtail/promtail-config.yml
+
+volumes:
+  promtail-prod-positions:
 
 networks:
   sys_default:

--- a/infra/docker-stack.monitoring.yml
+++ b/infra/docker-stack.monitoring.yml
@@ -80,6 +80,30 @@ services:
         condition: on-failure
     # ports 섹션 없음 → overlay 내부만 (Caddy가 tasks.prod_monitor_grafana:3000 으로 reverse_proxy)
 
+  # Loki — 로그 저장·쿼리 서버 (fs-03, Grafana 와 공존).
+  # ports 미노출 → overlay 내부에서만 접근 (Grafana, Promtail 이 tasks.prod_monitor_loki:3100).
+  loki:
+    image: grafana/loki:3.4.2
+    user: "10001:10001"   # Loki 기본 uid/gid — named volume 권한 일관성
+    command: -config.file=/etc/loki/config.yml
+    configs:
+      - source: prod_monitor_loki_yml
+        target: /etc/loki/config.yml
+    volumes:
+      - loki-data:/loki
+    networks:
+      - sys_default
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.prod_monitor_view == 1   # fs-03
+      resources:
+        limits:
+          memory: 400M
+      restart_policy:
+        condition: on-failure
+
 configs:
   # file: 경로는 compose 파일(infra/docker-stack.monitoring.yml)의 디렉토리 기준 상대경로.
   # → 실제 해석: /home/ubuntu/desktop/deploy/infra/<relative>
@@ -92,10 +116,14 @@ configs:
   prod_monitor_grafana_dashboards_yml:
     name: prod_monitor_grafana_dashboards_yml_${GRAFANA_DASH_CFG_HASH:-latest}
     file: ./grafana/provisioning/dashboards/dashboards.yml
+  prod_monitor_loki_yml:
+    name: prod_monitor_loki_yml_${LOKI_CFG_HASH:-latest}
+    file: ./loki/loki-config.yml
 
 volumes:
   prometheus-data:
   grafana-data:
+  loki-data:
 
 networks:
   sys_default:

--- a/infra/grafana/provisioning/datasources/datasources.yml
+++ b/infra/grafana/provisioning/datasources/datasources.yml
@@ -14,3 +14,19 @@ datasources:
     jsonData:
       timeInterval: "15s"           # Prometheus scrape_interval 과 일치
       httpMethod: POST              # 긴 쿼리에서 URL 길이 초과 방지
+
+  - name: Loki
+    uid: loki                       # 대시보드/Data Link 에서 참조 (변경 금지)
+    type: loki
+    access: proxy
+    url: http://tasks.prod_monitor_loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+      # Loki 로그 → Prometheus 메트릭 링크 (로그의 trace_id 필드 캡처 시 메트릭으로 점프)
+      # Pino 로그에 trace_id 필드가 없는 경우 매치되지 않을 뿐 오류 없음.
+      derivedFields:
+        - datasourceUid: prometheus
+          matcherRegex: "trace_id=(\\w+)"
+          name: TraceID
+          url: ""

--- a/infra/loki/loki-config.yml
+++ b/infra/loki/loki-config.yml
@@ -1,0 +1,55 @@
+auth_enabled: false
+
+# Loki 3.4.2 단일 바이너리 모드.
+# - filesystem storage (별도 객체 스토리지 미사용 — 단일 노드 fs-03 디스크)
+# - retention 7일 (Prometheus TSDB 와 보관 기간 통일)
+# - structured_metadata 활성 → Promtail 에서 container_name 등 고카디널리티 메타 저장
+# - ingestion rate 제한 → 1GB 노드 OOM 방지 안전장치
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9095
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2026-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 168h        # 7일
+  allow_structured_metadata: true
+  # 1GB 노드 (fs-03) OOM/디스크 폭주 보호
+  # 정상 트래픽(분당 수백 로그)은 KB/s 단위라 영향 없음, 폭증 시에만 드롭
+  ingestion_rate_mb: 4          # 초당 4MB 제한
+  ingestion_burst_size_mb: 6    # 순간 버스트 6MB 허용
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_query_series: 500
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 50
+  delete_request_store: filesystem
+
+# 외부 원격 사용량 수집 비활성화 (보안/프라이버시)
+analytics:
+  reporting_enabled: false

--- a/infra/promtail/promtail-config.yml
+++ b/infra/promtail/promtail-config.yml
@@ -1,0 +1,54 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+# 재시작 후 중복 수집 방지 — positions 파일은 promtail-prod-positions volume 으로 영속화
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://tasks.prod_monitor_loki:3100/loki/api/v1/push
+
+# Docker Swarm global mode 로 모든 노드에서 실행.
+# docker.sock 을 통해 각 노드의 컨테이너 stdout 을 자동 발견·수집.
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+
+    relabel_configs:
+      # Swarm 서비스 이름 (예: prod_nest_app, prod_next_app, infra_caddy, infra_redis)
+      # → 저카디널리티(~5개) 레이블 service 로 승격
+      - source_labels: ['__meta_docker_container_label_com_docker_swarm_service_name']
+        target_label: service
+
+      # 환경/클러스터 고정값 (카디널리티 1)
+      - target_label: env
+        replacement: prod
+      - target_label: cluster
+        replacement: oci-swarm
+
+      # ⚠️ container_name / container_id 는 레이블로 승격하지 않음
+      #   - Swarm 은 컨테이너 재시작마다 container_id 가 바뀌어 고카디널리티 유발
+      #   - 필요 시 LogQL line 필터(`|~ "patt"`)로 검색 가능
+
+    pipeline_stages:
+      # Pino JSON 파싱 — non-JSON 로그(Caddy, Redis 등)는 이 stage 가 실패해도
+      # drop 되지 않고 raw line 그대로 수집됨 (Promtail 기본 동작)
+      - json:
+          expressions:
+            level: level
+            time: time
+            msg: msg
+
+      # level 만 저카디널리티 레이블 승격 (info, warn, error, debug, fatal — 약 5종)
+      - labels:
+          level:
+
+      # Pino timestamp 파싱 — logger.module.ts 의 pino.stdTimeFunctions.isoTime 출력 형식:
+      # "time":"2024-01-01T00:00:00.000Z" (RFC 3339)
+      # Go 의 RFC3339Nano 포맷은 ms/ns 유무 모두 허용하므로 단일 format 으로 충분
+      - timestamp:
+          source: time
+          format: RFC3339Nano

--- a/src/common/logger/logger.module.ts
+++ b/src/common/logger/logger.module.ts
@@ -140,6 +140,15 @@ function redactSensitiveData(obj: unknown): unknown {
             formatters: {
               level: (label) => ({ level: label }),
             },
+            // Loki 저장량/조회 노이즈 차단.
+            // - /api/v1/metrics: Prometheus scrape (15s 간격 × replicas 분당 다수 요청)
+            // - /api/v1/health-check: Docker healthcheck + 외부 모니터링 probe
+            autoLogging: {
+              ignore: (req: { url?: string; originalUrl?: string }) => {
+                const url = (req.originalUrl || req.url || '').split('?')[0];
+                return url === '/api/v1/health-check' || url === '/api/v1/metrics';
+              },
+            },
           },
         };
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { register } from 'prom-client';
 import { AppModule } from './app.module';
 import { RedisIoAdapter } from './common/adapters/redis-io.adapter';
 import { OnlineUserService } from './modules/team/online-user.service';
@@ -16,6 +17,14 @@ import compression from 'compression';
 import { ALLOWED_ORIGINS } from './common/constants/cors.constants';
 
 async function bootstrap() {
+  // 모든 Prometheus 메트릭에 Swarm 레플리카 식별자 주입.
+  // docker-stack.app.yml 의 TASK_SLOT={{.Task.Slot}} 환경변수(1/2/3 …)로 전달됨.
+  // LOCAL 은 미설정 → '0'. AppModule 로드(= PrometheusModule.register) 전에 호출해야
+  // default metrics 에도 라벨이 붙는다.
+  register.setDefaultLabels({
+    replica: process.env.TASK_SLOT ?? '0',
+  });
+
   const logger = new Logger('Bootstrap');
 
   try {


### PR DESCRIPTION
- Loki 3.4.2 단일 바이너리 (fs-03, retention 7d, ingestion 4MB/s 제한, analytics off)
- Promtail 3.4.2 global mode — docker_sd 기반 stdout 수집
- 저카디널리티 레이블 4종 (service/env/cluster/level), timestamp RFC3339Nano
- Grafana Loki datasource provisioning + derivedFields(trace_id)
- deploy-monitoring: infra/loki, infra/promtail rsync + sha256 config hash
- NestJS Pino: PROD 한정 autoLogging.ignore (health-check, metrics 노이즈 차단)
- NestJS: register.setDefaultLabels({replica: TASK_SLOT}) — 메트릭에 레플리카 식별자 주입
- 설계 문서 교정: 버전 3.4.2, timestamp RFC3339Nano, structured_metadata 제거 근거