### PR TITLE
feat(monitor): redis_exporter 추가 — Redis 서버 메트릭 수집 (B1-2)

### DIFF
--- a/infra/docker-stack.monitoring.yml
+++ b/infra/docker-stack.monitoring.yml
@@ -80,6 +80,31 @@ services:
         condition: on-failure
     # ports 섹션 없음 → overlay 내부만 (Caddy가 tasks.prod_monitor_grafana:3000 으로 reverse_proxy)
 
+  # Redis 서버 메트릭 수집 exporter.
+  # - Redis 서버(fs-01)와 다른 노드(fs-02)에 배치 → 장애 도메인 분리
+  #   redis_up=0 발생 시 신호 조합으로 원인 구분:
+  #     • Redis 프로세스만 다운: redis_up=0 + node_exporter fs-01 정상
+  #     • fs-01 노드 다운: redis_up=0 + node_exporter fs-01 도 사라짐
+  #     • exporter 자체 문제: up{job="redis"}=0 + redis_up 부재
+  # - overlay DNS 로 Redis 접근 (무인증, 서비스 재배치 내성)
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    command:
+      - '--redis.addr=redis://tasks.infra_redis:6379'
+    networks:
+      - sys_default
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.prod_monitor_metrics == 1   # fs-02 (Prometheus 와 동일 노드)
+      resources:
+        limits:
+          memory: 50M
+      restart_policy:
+        condition: on-failure
+    # ports 없음 → overlay 내부에서만 Prometheus 가 scrape
+
   # Loki — 로그 저장·쿼리 서버 (fs-03, Grafana 와 공존).
   # ports 미노출 → overlay 내부에서만 접근 (Grafana, Promtail 이 tasks.prod_monitor_loki:3100).
   loki:

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -37,3 +37,12 @@ scrape_configs:
   - job_name: 'prometheus_self'
     static_configs:
       - targets: ['localhost:9090']
+
+  # Redis 서버 메트릭 — oliver006/redis_exporter 가 Redis 서버에 접속해 수집.
+  # 앱 관점(app_redis_connection_status) 과 구분되는 서버 관점 메트릭:
+  # redis_up, redis_memory_used_bytes, redis_commands_processed_total 등.
+  - job_name: 'redis'
+    dns_sd_configs:
+      - names: ['tasks.prod_monitor_redis-exporter']
+        type: A
+        port: 9121


### PR DESCRIPTION
- oliver006/redis_exporter:v1.62.0, fs-02 배치 (prod_monitor_metrics=1)
- 장애 도메인 분리: Redis(fs-01) vs exporter(fs-02) → redis_up=0 의 원인(프로세스/노드/exporter) 을 신호 조합으로 구분
- overlay DNS 기반 접근 (--redis.addr=redis://tasks.infra_redis:6379, 무인증)
- prometheus.yml 에 redis job 추가 (tasks.prod_monitor_redis-exporter:9121)
- memory 50M (현재 fs-02 여유 ~270M 중 50M 사용)