### PR TITLE
docs: 프론트 레플리카 수 갱신 (20 → 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Docker Swarm 기반. `main` 브랜치 push 시 GitHub Actions가 빌드 후 배�
 |---|---|
 | `infra` | caddy + redis + registry |
 | `prod_nest` | NestJS (3 replicas) — DNS `prod_nest_app:3500` |
-| `prod_next` | Next.js (20 replicas) — DNS `prod_next_app:3000` |
+| `prod_next` | Next.js (10 replicas) — DNS `prod_next_app:3000` |
 
 - 이미지 태그는 git SHA 7자 (`latest` 없음), 배포는 `docker stack deploy`로 통일
 - 배포 서버: fs-01 (ARM64, Manager) / fs-02 (registry) / fs-03 (모니터링)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -10,7 +10,7 @@
 | `infra` | `infra_redis` | 1 | fs-01 (Manager) | `infra_redis:6379` |
 | `infra` | `infra_registry` | 1 | fs-02 | `infra_registry:5000` (영속 bind mount) |
 | `prod_nest` | `prod_nest_app` | 3 | fs-01 | `prod_nest_app:3500` |
-| `prod_next` | `prod_next_app` | 20 | fs-01 | `prod_next_app:3000` |
+| `prod_next` | `prod_next_app` | 10 | fs-01 | `prod_next_app:3000` |
 
 ### 노드
 


### PR DESCRIPTION
next-bun의 스택 YAML을 10으로 줄인 것에 맞춰 문서를 정합화한다.
docs/tasks/archive/의 마이그레이션 이력 문서는 당시 사실 기록이므로
20 그대로 둔다.